### PR TITLE
Redirect to comments after a technology is added.

### DIFF
--- a/views/pages/addComment.ejs
+++ b/views/pages/addComment.ejs
@@ -40,7 +40,7 @@ getBreadcrumb = function () {
                 <div class="form-group">
                     <label for="comment">Comment</label>
                     <textarea class="form-control" rows="3" id="comment" name="comment"
-                              placeholder="Comment"></textarea>
+                              placeholder="Comment" required></textarea>
                 </div>
 
                 <button type="submit" class="btn btn-default">Add comment</button>
@@ -53,6 +53,9 @@ getBreadcrumb = function () {
 <% include ../partials/footer.ejs %>
 
 <script>
+    window.onbeforeunload = function(e) {
+        return "Please enter a comment.";
+    }
 
     $("form").submit(function (event) {
 
@@ -69,6 +72,7 @@ getBreadcrumb = function () {
             data: JSON.stringify(data),
             success: function (result) {
                 $(":submit").attr("disabled", false);
+                window.onbeforeunload = null; // disable the pop-up message 
                 if (result.success) {
                     location.href = "/technology/<%= technology.id %>";
                 } else {

--- a/views/pages/addTechnology.ejs
+++ b/views/pages/addTechnology.ejs
@@ -114,7 +114,7 @@
             data: JSON.stringify(frmdata),
             success: function (result) {
                 if (result.success) {
-                    location.href = "/technology/" + result.result;
+                    location.href = "/comments/add/" + result.result;
                 } else {
                     alert("There was an error adding the technology :)");
                 }


### PR DESCRIPTION
Resolves #12 
The comment isn't exactly forced. I added a popup message that appears when a user tries to leave the `comments/add` page without submitting one.
If we really want to force the initial comment, maybe we should do so by including the comment field in the form which adds a new technology?
