### PR TITLE
Make the technology name column unique

### DIFF
--- a/migrations/20161019150524-add-unique-technology-name-constraint.js
+++ b/migrations/20161019150524-add-unique-technology-name-constraint.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname + '/sqls/20161019150524-add-unique-technology-name-constraint-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname + '/sqls/20161019150524-add-unique-technology-name-constraint-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};

--- a/migrations/sqls/20161019150524-add-unique-technology-name-constraint-down.sql
+++ b/migrations/sqls/20161019150524-add-unique-technology-name-constraint-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE technologies DROP CONSTRAINT technology_name_constr;

--- a/migrations/sqls/20161019150524-add-unique-technology-name-constraint-up.sql
+++ b/migrations/sqls/20161019150524-add-unique-technology-name-constraint-up.sql
@@ -1,0 +1,9 @@
+-- Will not work if there are duplicate names in technologies
+-- To find duplicate technologies use:
+/*
+WITH duplicate_names AS 
+(select name, count(*) from technologies group by name HAVING count(*) > 1)
+SELECT t.id, t.name from technologies t
+INNER join duplicate_names dn ON dn.name=t.name;
+*/
+ALTER TABLE technologies ADD CONSTRAINT technology_name_constr UNIQUE (name);

--- a/views/pages/addTechnology.ejs
+++ b/views/pages/addTechnology.ejs
@@ -116,7 +116,7 @@
                 if (result.success) {
                     location.href = "/comments/add/" + result.result;
                 } else {
-                    alert("There was an error adding the technology :)");
+                    alert("There was an error adding the technology. Perhaps a technology with the same name already exists.");
                 }
 
                 $(":submit").attr("disabled", false);


### PR DESCRIPTION
Resolves #38 
The new migration won't run if there are any duplicate technology names.
I didn't want to remove duplicates automatically, to prevent deleting one that is referenced somewhere else. Instead I included this query, to help you find IDs of those duplicates:

```
WITH duplicate_names AS 
(select name, count(*) from technologies group by name HAVING count(*) > 1)
SELECT t.id, t.name from technologies t
INNER join duplicate_names dn ON dn.name=t.name;
```
