### PR TITLE
Feature/sticky search options

### DIFF
--- a/public/lib/cookie.js
+++ b/public/lib/cookie.js
@@ -1,0 +1,156 @@
+/*!
+ * JavaScript Cookie v2.1.3
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+;(function (factory) {
+	var registeredInModuleLoader = false;
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+		registeredInModuleLoader = true;
+	}
+	if (typeof exports === 'object') {
+		module.exports = factory();
+		registeredInModuleLoader = true;
+	}
+	if (!registeredInModuleLoader) {
+		var OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			var result;
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					var expires = new Date();
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
+				}
+
+				try {
+					result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				if (!converter.write) {
+					value = encodeURIComponent(String(value))
+						.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				} else {
+					value = converter.write(value, key);
+				}
+
+				key = encodeURIComponent(String(key));
+				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+				key = key.replace(/[\(\)]/g, escape);
+
+				return (document.cookie = [
+					key, '=', value,
+					attributes.expires ? '; expires=' + attributes.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+					attributes.path ? '; path=' + attributes.path : '',
+					attributes.domain ? '; domain=' + attributes.domain : '',
+					attributes.secure ? '; secure' : ''
+				].join(''));
+			}
+
+			// Read
+
+			if (!key) {
+				result = {};
+			}
+
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()"
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var rdecode = /(%[0-9A-Z]{2})+/g;
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var cookie = parts.slice(1).join('=');
+
+				if (cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					var name = parts[0].replace(rdecode, decodeURIComponent);
+					cookie = converter.read ?
+						converter.read(cookie, name) : converter(cookie, name) ||
+						cookie.replace(rdecode, decodeURIComponent);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					if (key === name) {
+						result = cookie;
+						break;
+					}
+
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
+			}
+
+			return result;
+		}
+
+		api.set = api;
+		api.get = function (key) {
+			return api.call(api, key);
+		};
+		api.getJSON = function () {
+			return api.apply({
+				json: true
+			}, [].slice.call(arguments));
+		};
+		api.defaults = {};
+
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init(function () {});
+}));

--- a/public/stickyTablePageSize.js
+++ b/public/stickyTablePageSize.js
@@ -2,7 +2,6 @@ var page_size = 10; //Default size
 
 if (Cookies.get('page_size') != null ) {
     page_size = Cookies.get('page_size');
-    $('#inpost-users-table').data('page-size', page_size);
 }
 
 // Set a cookie to remember the chosen number of records per page 

--- a/views/pages/addProjectToTechnology.ejs
+++ b/views/pages/addProjectToTechnology.ejs
@@ -73,9 +73,11 @@ getBreadcrumb = function() {
 
 <% include ../partials/footer.ejs %>
 
-
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
+
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+    
     $table = $('#linkedProjects');
     $deleteBtn = $('#deleteBtn');
 
@@ -91,6 +93,7 @@ getBreadcrumb = function() {
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/addProjectToTechnology.ejs
+++ b/views/pages/addProjectToTechnology.ejs
@@ -74,9 +74,9 @@ getBreadcrumb = function() {
 <% include ../partials/footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
 
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
     
     $table = $('#linkedProjects');
     $deleteBtn = $('#deleteBtn');
@@ -93,7 +93,7 @@ getBreadcrumb = function() {
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
+        pageSize: page_size, // declared and set in stickyTablePageSize.js
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/addTechnologyToProject.ejs
+++ b/views/pages/addTechnologyToProject.ejs
@@ -60,6 +60,8 @@
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
+    
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
     $table = $('#results');
 
@@ -80,6 +82,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
         onPostBody: function() { 
             setupVersionsModal();
             setupVersionDropdowns();

--- a/views/pages/addTechnologyToProject.ejs
+++ b/views/pages/addTechnologyToProject.ejs
@@ -59,9 +59,9 @@
 <% include ../partials/software-versions-footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
     
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
     $table = $('#results');
 
@@ -82,7 +82,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
+        pageSize: page_size, // declared and set in stickyTablePageSize.js 
         onPostBody: function() { 
             setupVersionsModal();
             setupVersionDropdowns();

--- a/views/pages/admin/listCategories.ejs
+++ b/views/pages/admin/listCategories.ejs
@@ -62,9 +62,9 @@
 <% include ../../partials/footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
 
-    <% include ../../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
@@ -81,7 +81,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
+        pageSize: page_size, // declared and set in stickyTablePageSize.js 
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/admin/listCategories.ejs
+++ b/views/pages/admin/listCategories.ejs
@@ -63,6 +63,9 @@
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
+
+    <% include ../../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
 
@@ -78,6 +81,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/admin/listTechnologies.ejs
+++ b/views/pages/admin/listTechnologies.ejs
@@ -62,10 +62,11 @@
 
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
+
 <script>
 
-    <% include ../../partials/sticky-table-page-size.ejs %> // contains the page_size variable
-    
+
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
 
@@ -84,7 +85,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
+        pageSize: page_size, // declared and set in stickyTablePageSize.js 
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/admin/listTechnologies.ejs
+++ b/views/pages/admin/listTechnologies.ejs
@@ -64,6 +64,8 @@
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
 
+    <% include ../../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+    
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
 
@@ -82,6 +84,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/admin/user/listUsers.ejs
+++ b/views/pages/admin/user/listUsers.ejs
@@ -64,6 +64,8 @@
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
 
+    <% include ../../../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
 
@@ -82,6 +84,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/admin/user/listUsers.ejs
+++ b/views/pages/admin/user/listUsers.ejs
@@ -62,9 +62,9 @@
 <% include ../../../partials/footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
 
-    <% include ../../../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
@@ -84,7 +84,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
+        pageSize: page_size, // declared and set in stickyTablePageSize.js 
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/editVersions.ejs
+++ b/views/pages/editVersions.ejs
@@ -54,6 +54,9 @@
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
+    
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+    
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
     $editBtn = $('#editBtn');
@@ -70,6 +73,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/editVersions.ejs
+++ b/views/pages/editVersions.ejs
@@ -53,9 +53,9 @@
 <% include ../partials/software-versions-footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
     
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
     
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
@@ -73,7 +73,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
+        pageSize: page_size, // declared and set in stickyTablePageSize.js 
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/listStacks.ejs
+++ b/views/pages/listStacks.ejs
@@ -65,6 +65,8 @@
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
 
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+    
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
 
@@ -80,6 +82,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/listStacks.ejs
+++ b/views/pages/listStacks.ejs
@@ -63,9 +63,9 @@
 <% include ../partials/footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
 
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
     
     $table = $('#results');
     $deleteBtn = $('#deleteBtn')
@@ -82,7 +82,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
+        pageSize: page_size, // declared and set in stickyTablePageSize.js
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/removeTechnologyFromProject.ejs
+++ b/views/pages/removeTechnologyFromProject.ejs
@@ -59,9 +59,9 @@
 
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
     
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
     $table = $('#results');
 
@@ -82,7 +82,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
+        pageSize: page_size, // declared and set in stickyTablePageSize.js
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/removeTechnologyFromProject.ejs
+++ b/views/pages/removeTechnologyFromProject.ejs
@@ -60,6 +60,8 @@
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
+    
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
     $table = $('#results');
 
@@ -80,6 +82,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
         columns: [{
             field:'state',
             checkbox:'true'

--- a/views/pages/searchProjects.ejs
+++ b/views/pages/searchProjects.ejs
@@ -71,9 +71,9 @@
 <% include ../partials/footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
 
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
     
     $table = $('#results');
 
@@ -92,7 +92,7 @@
         searchOnEnterKey: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
+        pageSize: page_size, // declared and set in stickyTablePageSize.js 
         columns: [
         <% if(user.admin) { %>
             {

--- a/views/pages/searchProjects.ejs
+++ b/views/pages/searchProjects.ejs
@@ -73,6 +73,8 @@
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
 
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+    
     $table = $('#results');
 
     $table.bootstrapTable({
@@ -90,6 +92,7 @@
         searchOnEnterKey: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
         columns: [
         <% if(user.admin) { %>
             {

--- a/views/pages/searchTechnologies.ejs
+++ b/views/pages/searchTechnologies.ejs
@@ -48,6 +48,7 @@
 
 <% include ../partials/footer.ejs %>
 
+<script src="/lib/cookie.js"></script>
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
 
@@ -68,6 +69,13 @@
     };
     <% } %>
 
+    var page_size = 10; //Default size
+
+    if (Cookies.get('technology_search_page_size') != null ) {
+        page_size = Cookies.get('technology_search_page_size');
+        $('#inpost-users-table').data('page-size', page_size);
+    }
+    
     $('#results').bootstrapTable({
         method: 'get',
         url: '/api/technology',
@@ -82,6 +90,7 @@
         searchOnEnterKey: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size,
         columns: [{
             field: 'id',
             title: 'Item ID',
@@ -167,6 +176,14 @@
             '</a>'
         ].join('');
     }
+
+    // Set a cookie to remember the chosen number of records per page 
+    $(document).on('click', '.dropdown-menu', function() {
+        var size_selected = $('.pagination-detail .page-size').text();
+        if (Cookies.get('cookieconsent_dismissed') == 'yes') {
+            Cookies.set('technology_search_page_size', size_selected);
+        }
+    }); 
 
 </script>
 

--- a/views/pages/searchTechnologies.ejs
+++ b/views/pages/searchTechnologies.ejs
@@ -49,6 +49,7 @@
 <% include ../partials/footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
 
     <% if(user.canComment) { %>
@@ -68,8 +69,6 @@
     };
     <% } %>
 
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
-
     $('#results').bootstrapTable({
         method: 'get',
         url: '/api/technology',
@@ -84,7 +83,7 @@
         searchOnEnterKey: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
+        pageSize: page_size, // declared and set in stickyTablePageSize.js 
         columns: [{
             field: 'id',
             title: 'Item ID',

--- a/views/pages/searchTechnologies.ejs
+++ b/views/pages/searchTechnologies.ejs
@@ -48,7 +48,6 @@
 
 <% include ../partials/footer.ejs %>
 
-<script src="/lib/cookie.js"></script>
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
 
@@ -69,13 +68,8 @@
     };
     <% } %>
 
-    var page_size = 10; //Default size
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
-    if (Cookies.get('technology_search_page_size') != null ) {
-        page_size = Cookies.get('technology_search_page_size');
-        $('#inpost-users-table').data('page-size', page_size);
-    }
-    
     $('#results').bootstrapTable({
         method: 'get',
         url: '/api/technology',
@@ -90,7 +84,7 @@
         searchOnEnterKey: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs 
         columns: [{
             field: 'id',
             title: 'Item ID',
@@ -176,14 +170,6 @@
             '</a>'
         ].join('');
     }
-
-    // Set a cookie to remember the chosen number of records per page 
-    $(document).on('click', '.dropdown-menu', function() {
-        var size_selected = $('.pagination-detail .page-size').text();
-        if (Cookies.get('cookieconsent_dismissed') == 'yes') {
-            Cookies.set('technology_search_page_size', size_selected);
-        }
-    }); 
 
 </script>
 

--- a/views/pages/statushistory.ejs
+++ b/views/pages/statushistory.ejs
@@ -48,9 +48,9 @@
 
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
 
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
     
     $('#results').bootstrapTable( {
         method: 'get',
@@ -64,7 +64,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
+        pageSize: page_size, // declared and set in stickyTablePageSize.js
         columns: [ {
             field: 'id',
             title: 'ID',

--- a/views/pages/statushistory.ejs
+++ b/views/pages/statushistory.ejs
@@ -50,6 +50,8 @@
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
 
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+    
     $('#results').bootstrapTable( {
         method: 'get',
         url: '/api/technology/<%=technology.id%>/status/history',
@@ -62,6 +64,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
         columns: [ {
             field: 'id',
             title: 'ID',

--- a/views/pages/technologyUsers.ejs
+++ b/views/pages/technologyUsers.ejs
@@ -50,6 +50,8 @@ getBreadcrumb = function () {
 
 <script>
 
+<% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+
 $('#results').bootstrapTable({
     method: 'get',
     url: '/api/technology/<%= technology.id %>/users',
@@ -64,6 +66,7 @@ $('#results').bootstrapTable({
     searchOnEnterKey: true,
     showPaginationSwitch: true,
     pagination: true,
+    pageSize: page_size, // declared and set in sticky-table-page-size.ejs
     columns: [{
         field: 'displayname',
         title: 'Name',

--- a/views/pages/technologyUsers.ejs
+++ b/views/pages/technologyUsers.ejs
@@ -47,10 +47,10 @@ getBreadcrumb = function () {
 <% include ../partials/footer.ejs %>
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 
 <script>
 
-<% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
 $('#results').bootstrapTable({
     method: 'get',
@@ -66,7 +66,7 @@ $('#results').bootstrapTable({
     searchOnEnterKey: true,
     showPaginationSwitch: true,
     pagination: true,
-    pageSize: page_size, // declared and set in sticky-table-page-size.ejs
+    pageSize: page_size, // declared and set in stickyTablePageSize.js
     columns: [{
         field: 'displayname',
         title: 'Name',

--- a/views/pages/updateStatus.ejs
+++ b/views/pages/updateStatus.ejs
@@ -75,6 +75,8 @@
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
 
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
+    
     $('#results').bootstrapTable( {
         method: 'get',
         url: '/api/technology/<%=technology.id%>/status/history',
@@ -87,6 +89,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
         columns: [ {
             field: 'id',
             title: 'ID',

--- a/views/pages/updateStatus.ejs
+++ b/views/pages/updateStatus.ejs
@@ -73,9 +73,9 @@
 
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
 
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
     
     $('#results').bootstrapTable( {
         method: 'get',
@@ -89,7 +89,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
+        pageSize: page_size, // declared and set in stickyTablePageSize.js
         columns: [ {
             field: 'id',
             title: 'ID',

--- a/views/pages/votehistory.ejs
+++ b/views/pages/votehistory.ejs
@@ -49,6 +49,8 @@
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
 <script>
+    
+    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
     $('#results').bootstrapTable( {
         method: 'get',
@@ -62,6 +64,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
+        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
         columns: [ {
             field: 'id',
             title: 'ID',

--- a/views/pages/votehistory.ejs
+++ b/views/pages/votehistory.ejs
@@ -48,9 +48,9 @@
 
 
 <script src="/lib/bootstrap-table/bootstrap-table.min.js"></script>
+<script src="/stickyTablePageSize.js"></script>
 <script>
     
-    <% include ../partials/sticky-table-page-size.ejs %> // contains the page_size variable
 
     $('#results').bootstrapTable( {
         method: 'get',
@@ -64,7 +64,7 @@
         showRefresh: true,
         showPaginationSwitch: true,
         pagination: true,
-        pageSize: page_size, // declared and set in sticky-table-page-size.ejs
+        pageSize: page_size, // declared and set in stickyTablePageSize.js
         columns: [ {
             field: 'id',
             title: 'ID',

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -12,4 +12,5 @@
 
 <!-- <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script> §-->
 <script src="/lib/jquery.min.js"></script>
+<script src="/lib/cookie.js"></script>
 <script src="/lib/bootstrap/js/bootstrap.min.js"></script>

--- a/views/partials/sticky-table-page-size.ejs
+++ b/views/partials/sticky-table-page-size.ejs
@@ -1,0 +1,14 @@
+var page_size = 10; //Default size
+
+if (Cookies.get('page_size') != null ) {
+    page_size = Cookies.get('page_size');
+    $('#inpost-users-table').data('page-size', page_size);
+}
+
+// Set a cookie to remember the chosen number of records per page 
+$(document).on('click', '.dropdown-menu', function() {
+    var size_selected = $('.pagination-detail .page-size').text();
+    if (Cookies.get('cookieconsent_dismissed') == 'yes') {
+        Cookies.set('page_size', size_selected);
+    }
+}); 


### PR DESCRIPTION
Resolves #42 
Let me know if it's ok if all bootstrap tables read the same cookie value to determine the # of displayed rows.
Edit: It might be worth adding the cookie consent message to the index page. It's easy to miss the 'Got it!' button on the login page and if a user skips it, search options will not be saved to cookies.