### PR TITLE
remove prepopulated text in licence link on tech edit page

### DIFF
--- a/views/pages/editTechnology.ejs
+++ b/views/pages/editTechnology.ejs
@@ -73,7 +73,7 @@
                 <label for="technologyLicenceLink">Licence details</label>
                 <input type="url" class="form-control" id="technologyLicenceLink"
                        name="technologyLicenceLink" placeholder="Licence info link"
-                       value="<%= (technology.licencelink == null ? "http://" : technology.licencelink) %>"
+                       value="<%= technology.licencelink %>"
                        maxlength="200">
             </div>
             <div class="form-group">


### PR DESCRIPTION
Fixes #34 