### PR TITLE
Display projects in alphabetical order

### DIFF
--- a/dao/projects.js
+++ b/dao/projects.js
@@ -13,7 +13,8 @@ Projects.getAll = function (done) {
         FROM projects AS p
         LEFT OUTER JOIN tag_project_link tpl ON tpl.projectid=p.id
         LEFT OUTER JOIN tags t ON tpl.tagid=t.id
-        GROUP BY p.id`;
+        GROUP BY p.id
+        ORDER BY p.name ASC`;
 
     dbhelper.query(sql, null,
         function (results) {


### PR DESCRIPTION
Currently when adding a project to a technology the projects are listed in the
order they were retrieved from the database. In order to aid user experience the
projects should be ordered sensibly.

Connects to #102