### PR TITLE
Add travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- '6'

--- a/test/dao/usersTest.js
+++ b/test/dao/usersTest.js
@@ -4,7 +4,7 @@ var expect = chai.expect;
 
 var dbhelper = require('../../utils/dbhelper.js');
 var usersDao = require('../../dao/users');
-var User = require('../../models/user');
+var User = require('../../models/User');
 
 describe("dao/users", function() {
         var dbhelperQuerySpy;


### PR DESCRIPTION
Because there was no .travis.yml file the CI server was defaulting to ruby and throwing an error when it couldn't find a Rakefile. This configuration instructs travis that this project is node and therefore it should use npm to drive testing.