### PR TITLE
Fix migrations.

### DIFF
--- a/migrations/20160525082319-create-db.js
+++ b/migrations/20160525082319-create-db.js
@@ -1,4 +1,4 @@
-dbm = dbm || require('db-migrate');
+var dbm = dbm || require('db-migrate');
 var type = dbm.dataType;
 var fs = require('fs');
 var path = require('path');

--- a/migrations/20160530125324-store-avatars-in-db.js
+++ b/migrations/20160530125324-store-avatars-in-db.js
@@ -1,4 +1,4 @@
-dbm = dbm || require('db-migrate');
+var dbm = dbm || require('db-migrate');
 var type = dbm.dataType;
 var fs = require('fs');
 var path = require('path');

--- a/migrations/20160607111142-add-roles.js
+++ b/migrations/20160607111142-add-roles.js
@@ -1,4 +1,4 @@
-dbm = dbm || require('db-migrate');
+var dbm = dbm || require('db-migrate');
 var type = dbm.dataType;
 var fs = require('fs');
 var path = require('path');

--- a/migrations/20160607132947-add-status.js
+++ b/migrations/20160607132947-add-status.js
@@ -1,4 +1,4 @@
-dbm = dbm || require('db-migrate');
+var dbm = dbm || require('db-migrate');
 var type = dbm.dataType;
 var fs = require('fs');
 var path = require('path');

--- a/migrations/20160622195458-alter-vote-constraint.js
+++ b/migrations/20160622195458-alter-vote-constraint.js
@@ -1,4 +1,4 @@
-dbm = dbm || require('db-migrate');
+var dbm = dbm || require('db-migrate');
 var type = dbm.dataType;
 var fs = require('fs');
 var path = require('path');


### PR DESCRIPTION
On node versions 10.19.0 and 12.16.3 it is not possible run migrations. Fixed problem in this commit. Issue #109 

Exception-Message:
```
[ERROR] AssertionError [ERR_ASSERTION]: ifError got unwanted exception: dbm is not defined
    at /TechRadar/node_modules/db-migrate/lib/commands/on-complete.js:15:14
    at tryCatcher (/TechRadar/node_modules/bluebird/js/release/util.js:16:23)
    at Promise.successAdapter (/TechRadar/node_modules/bluebird/js/release/nodeify.js:22:30)
    at Promise._settlePromise (/TechRadar/node_modules/bluebird/js/release/promise.js:601:21)
    at Promise._settlePromiseCtx (/TechRadar/node_modules/bluebird/js/release/promise.js:641:10)
    at _drainQueueStep (/TechRadar/node_modules/bluebird/js/release/async.js:97:12)
    at _drainQueue (/TechRadar/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/TechRadar/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/TechRadar/node_modules/bluebird/js/release/async.js:15:14)
    at Object.<anonymous> (/TechRadar/migrations/20160525082319-create-db.js:1:1)
    at Module._compile (internal/modules/cjs/loader.js:1133:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
    at Module.require (internal/modules/cjs/loader.js:1019:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Class.setup (/TechRadar/node_modules/db-migrate/lib/skeleton.js:158:12)
    at /TechRadar/node_modules/db-migrate/lib/migrator.js:231:41
From previous event:
    at /TechRadar/node_modules/db-migrate/lib/migrator.js:230:18
From previous event:
    at /TechRadar/node_modules/db-migrate/lib/migrator.js:225:14
    at /TechRadar/node_modules/db-migrate/lib/migration.js:368:7
    at processImmediate (internal/timers.js:456:21)
```